### PR TITLE
Added a .syntastic_cpp_config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ Session.vim
 tags
 # syntastic
 .syntastic_clang_tidy_config
-.syntastic_cpp_config
 
 ################################################################################
 # C++

--- a/.syntastic_cpp_config
+++ b/.syntastic_cpp_config
@@ -1,0 +1,10 @@
+-std=c++14
+-Ibuild
+-I.
+-Ibuild/vendor/googlebenchmark/src/googlebenchmark/include
+-Ibuild/vendor/googlelog/src/googlelog/src
+-Ibuild/vendor/googletest/src/googletest/googlemock/include
+-Ibuild/vendor/googletest/src/googletest/googletest/include
+-Ibuild/vendor/range-v3/range-v3-prefix/src/range-v3/include
+-Ibuild/vendor/zeromqcpp/zeromqcpp-prefix/src/zeromqcpp
+-Ibuild/vendor/zeromq/src/zeromq/include


### PR DESCRIPTION
[Syntastic][1] is a vim plugin for syntax checking. By default, syntastic gets a bit confused when syntax checking C++; it doesn't know exactly where to find all the included files. To make syntastic usable, we have to add a `.syntastic_cpp_config` file with the locations of all the header files we include. The header include paths are taken from the root `CMakeLists.txt` file.

[1]: https://github.com/vim-syntastic/syntastic