### PR TITLE
Minor .syntastic_cpp_config tweaks.

### DIFF
--- a/.syntastic_cpp_config
+++ b/.syntastic_cpp_config
@@ -1,6 +1,10 @@
 -std=c++14
+-Wall
+-Wextra
+-Werror
+-pedantic
 -Ibuild
--I.
+-Isrc
 -Ibuild/vendor/googlebenchmark/src/googlebenchmark/include
 -Ibuild/vendor/googlelog/src/googlelog/src
 -Ibuild/vendor/googletest/src/googletest/googlemock/include


### PR DESCRIPTION
- `-I.` should have been `-Isrc` since those paths are relative to where the `.syntastic_cpp_config` file lives which is in the root directory of the repo.
- Added `-Wall -Wextra -Werror -pedantic` flags that should have been there all along.