### PR TITLE
Made infix ops free functions in infix namespace.

### DIFF
--- a/src/examples/chat/chat_client.cc
+++ b/src/examples/chat/chat_client.cc
@@ -4,6 +4,7 @@
 
 #include "fluent/fluent_builder.h"
 #include "fluent/fluent_executor.h"
+#include "fluent/infix.h"
 #include "ra/all.h"
 
 namespace ra = fluent::ra;
@@ -37,6 +38,8 @@ int main(int argc, char* argv[]) {
           .table<int>("bootstrap_dummy")
           .RegisterRules([&](auto& in, auto& out, auto& connect, auto& mcast,
                              auto& dummy) {
+            using namespace fluent::infix;
+
             auto bootstrap_a =
                 connect <= (dummy.Iterable() | ra::count() |
                             ra::filter([](const std::tuple<std::size_t>& t) {

--- a/src/examples/chat/chat_server.cc
+++ b/src/examples/chat/chat_server.cc
@@ -4,6 +4,7 @@
 
 #include "fluent/fluent_builder.h"
 #include "fluent/fluent_executor.h"
+#include "fluent/infix.h"
 #include "ra/all.h"
 
 namespace ra = fluent::ra;
@@ -31,6 +32,8 @@ int main(int argc, char* argv[]) {
           .channel<address_t, message_t>("mcast")
           .table<client_address_t, nickname_t>("nodelist")
           .RegisterRules([&](auto& connect, auto& mcast, auto& nodelist) {
+            using namespace fluent::infix;
+
             auto subscribe =
                 nodelist <= (connect.Iterable() | ra::project<1, 2>());
 

--- a/src/fluent/channel.h
+++ b/src/fluent/channel.h
@@ -64,12 +64,6 @@ class Channel {
     MergeImpl(ra, std::make_index_sequence<sizeof...(Ts) + 1>());
   }
 
-  template <typename Rhs>
-  std::tuple<Channel<T, Ts...>*, MergeTag, typename std::decay<Rhs>::type>
-  operator<=(Rhs&& rhs) {
-    return {this, MergeTag(), std::forward<Rhs>(rhs)};
-  }
-
   void Tick() { ts_.clear(); }
 
   // `Collection<T1, ..., Tn>.GetParser()(columns)` parses a vector of `n`

--- a/src/fluent/fluent_builder_test.cc
+++ b/src/fluent/fluent_builder_test.cc
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 #include "zmq.hpp"
 
+#include "fluent/infix.h"
 #include "ra/all.h"
 
 namespace fluent {
@@ -22,6 +23,7 @@ TEST(FluentBuilder, SimpleBuildCheck) {
     .channel<std::string, int>("c")
     .stdout()
     .RegisterRules([](auto& t, auto& s, auto& c, auto& out) {
+      using namespace fluent::infix;
       auto rule_a = t <= s.Iterable();
       auto rule_b = t += s.Iterable();
       auto rule_c = t -= s.Iterable();

--- a/src/fluent/fluent_executor_test.cc
+++ b/src/fluent/fluent_executor_test.cc
@@ -12,6 +12,7 @@
 
 #include "fluent/channel.h"
 #include "fluent/fluent_builder.h"
+#include "fluent/infix.h"
 #include "ra/all.h"
 #include "testing/captured_stdout.h"
 
@@ -28,6 +29,7 @@ TEST(FluentExecutor, SimpleProgram) {
     .scratch<int, int, float>("s")
     .channel<std::string, float, char>("c")
     .RegisterRules([](auto& t, auto& s, auto& c) {
+      using namespace fluent::infix;
       return std::make_tuple(
         t <= (t.Iterable() | ra::count()),
         t <= (s.Iterable() | ra::count()),
@@ -69,6 +71,7 @@ TEST(FluentExecutor, AllOperations) {
     .scratch<int>("s")
     .stdout()
     .RegisterRules([&int_tuple_to_string](auto& t, auto& s, auto& stdout) {
+      using namespace fluent::infix;
       auto a = t <= (t.Iterable() | ra::count());
       auto b = t += t.Iterable();
       auto c = t -= s.Iterable();
@@ -109,6 +112,7 @@ TEST(FluentExecutor, SimpleCommunication) {
   auto ping = fluent("inproc://ping", &context)
     .channel<std::string, int>("c")
     .RegisterRules([&reroute](auto& c) {
+      using namespace fluent::infix;
       return std::make_tuple(
         c <= (c.Iterable() | ra::map(reroute("inproc://pong")))
       );
@@ -116,6 +120,7 @@ TEST(FluentExecutor, SimpleCommunication) {
   auto pong = fluent("inproc://pong", &context)
     .channel<std::string, int>("c")
     .RegisterRules([&reroute](auto& c) {
+      using namespace fluent::infix;
       return std::make_tuple(
         c <= (c.Iterable() | ra::map(reroute("inproc://ping")))
       );
@@ -156,6 +161,7 @@ TEST(FluentExecutor, ComplexProgram) {
                .table<int>("t")
                .scratch<int>("s")
                .RegisterRules([plus_one_times_two, is_even](auto& t, auto& s) {
+                 using namespace fluent::infix;
                  auto a = t += (s.Iterable() | ra::count());
                  auto b = t <= (t.Iterable() | ra::map(plus_one_times_two));
                  auto c = s <= t.Iterable();

--- a/src/fluent/infix.h
+++ b/src/fluent/infix.h
@@ -1,0 +1,102 @@
+#ifndef FLUENT_INFIX_H_
+#define FLUENT_INFIX_H_
+
+#include <tuple>
+
+#include "fluent/rule_tags.h"
+#include "fluent/table.h"
+
+namespace fluent {
+namespace infix {
+
+// # Overview
+// Recall from `rule_tags.h` (which you should read, if you haven't already)
+// that fluent represents a rule as a triple (lhs, type, rhs) where:
+//
+//   - `lhs` is a pointer to a collection,
+//   - `type` is an instance of one of the structs below, and
+//   - `rhs` is a relational algebra expression.
+//
+// This file provides three infix functions:
+//
+//   - <= (merge)
+//   - += (deferred merge)
+//   - -= (deferred delete)
+//
+// to make constructing rules quite a bit sweeter. For example, consider the
+// following snippet of code.
+//
+//   using namespace fluent::infix;
+//   Table<int> t;
+//   Scratch<float> s;
+//   auto rule = t <= s.Iterable() | ra::count();
+//
+// Here, `rule` is the tuple `(&t, MergeTag(), s.Iterable() | ra::count())`.
+// See `fluent_executor_test.cc` for more complete examples of how to construct
+// rules and pass them to a FluentExecutor.
+//
+// # Some Things to Note
+// - Every infix function takes its first argument as a non-const reference.
+//   Yes, this is disallowed by the Google style guide, but since these
+//   functions exist purely for syntactic sugar, I think it's okay.
+// - The rules returned by calling these infix functions return a pointer to
+//   their first argument. Thus, you must make sure that the first argument
+//   outlives the rule.
+// - The infix functions live in their own namespace `fluent::infix` for code
+//   hygiene (similar to std::literals::string_literals or
+//   std::literals::chrono_literals), so make sure to add `using namespace
+//   fluent::infix` before using the functions.
+
+// Table <=
+template <typename... Ts, typename Rhs>
+std::tuple<Table<Ts...>*, MergeTag, typename std::decay<Rhs>::type> operator<=(
+    Table<Ts...>& t, Rhs&& rhs) {
+  return {&t, MergeTag(), std::forward<Rhs>(rhs)};
+}
+
+// Table +=
+template <typename... Ts, typename Rhs>
+std::tuple<Table<Ts...>*, DeferredMergeTag, typename std::decay<Rhs>::type>
+operator+=(Table<Ts...>& t, Rhs&& rhs) {
+  return {&t, DeferredMergeTag(), std::forward<Rhs>(rhs)};
+}
+
+// Table -=
+template <typename... Ts, typename Rhs>
+std::tuple<Table<Ts...>*, DeferredDeleteTag, typename std::decay<Rhs>::type>
+operator-=(Table<Ts...>& t, Rhs&& rhs) {
+  return {&t, DeferredDeleteTag(), std::forward<Rhs>(rhs)};
+}
+
+// Channel <=
+template <typename... Ts, typename Rhs>
+std::tuple<Channel<Ts...>*, MergeTag, typename std::decay<Rhs>::type>
+operator<=(Channel<Ts...>& c, Rhs&& rhs) {
+  return {&c, MergeTag(), std::forward<Rhs>(rhs)};
+}
+
+// Scratch <=
+template <typename... Ts, typename Rhs>
+std::tuple<Scratch<Ts...>*, MergeTag, typename std::decay<Rhs>::type>
+operator<=(Scratch<Ts...>& s, Rhs&& rhs) {
+  return {&s, MergeTag(), std::forward<Rhs>(rhs)};
+}
+
+// Stdout <=
+template <typename... Ts, typename Rhs>
+std::tuple<Stdout*, MergeTag, typename std::decay<Rhs>::type> operator<=(
+    Stdout& o, Rhs&& rhs) {
+  return {&o, MergeTag(), std::forward<Rhs>(rhs)};
+}
+
+// Stdout +=
+template <typename Rhs>
+std::tuple<Stdout*, DeferredMergeTag, typename std::decay<Rhs>::type>
+operator+=(Stdout& o, Rhs&& rhs) {
+  return {&o, DeferredMergeTag(), std::forward<Rhs>(rhs)};
+}
+
+}  // namespace infix
+}  // namespace fluent
+
+#endif  // FLUENT_INFIX_H_

--- a/src/fluent/scratch.h
+++ b/src/fluent/scratch.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <tuple>
 
-#include "fluent/rule_tags.h"
 #include "ra/iterable.h"
 
 namespace fluent {
@@ -37,12 +36,6 @@ class Scratch {
     auto begin = std::make_move_iterator(std::begin(buf));
     auto end = std::make_move_iterator(std::end(buf));
     ts_.insert(begin, end);
-  }
-
-  template <typename Rhs>
-  std::tuple<Scratch<Ts...>*, MergeTag, typename std::decay<Rhs>::type>
-  operator<=(Rhs&& rhs) {
-    return {this, MergeTag(), std::forward<Rhs>(rhs)};
   }
 
   void Tick() { ts_.clear(); }

--- a/src/fluent/stdout.h
+++ b/src/fluent/stdout.h
@@ -11,7 +11,6 @@
 #include "range/v3/all.hpp"
 
 #include "common/macros.h"
-#include "fluent/rule_tags.h"
 #include "ra/ra_util.h"
 
 namespace fluent {
@@ -37,18 +36,6 @@ class Stdout {
   template <typename RA>
   void DeferredMerge(const RA& ra) {
     ra::StreamRaInto(ra, &deferred_merge_);
-  }
-
-  template <typename Rhs>
-  std::tuple<Stdout*, MergeTag, typename std::decay<Rhs>::type> operator<=(
-      Rhs&& rhs) {
-    return {this, MergeTag(), std::forward<Rhs>(rhs)};
-  }
-
-  template <typename Rhs>
-  std::tuple<Stdout*, DeferredMergeTag, typename std::decay<Rhs>::type>
-  operator+=(Rhs&& rhs) {
-    return {this, DeferredMergeTag(), std::forward<Rhs>(rhs)};
   }
 
   void Tick() {

--- a/src/fluent/table.h
+++ b/src/fluent/table.h
@@ -9,7 +9,6 @@
 
 #include "range/v3/all.hpp"
 
-#include "fluent/rule_tags.h"
 #include "ra/iterable.h"
 #include "ra/ra_util.h"
 
@@ -41,24 +40,6 @@ class Table {
   template <typename RA>
   void DeferredDelete(const RA& ra) {
     ra::StreamRaInto(ra, &deferred_delete_);
-  }
-
-  template <typename Rhs>
-  std::tuple<Table<Ts...>*, MergeTag, typename std::decay<Rhs>::type>
-  operator<=(Rhs&& rhs) {
-    return {this, MergeTag(), std::forward<Rhs>(rhs)};
-  }
-
-  template <typename Rhs>
-  std::tuple<Table<Ts...>*, DeferredMergeTag, typename std::decay<Rhs>::type>
-  operator+=(Rhs&& rhs) {
-    return {this, DeferredMergeTag(), std::forward<Rhs>(rhs)};
-  }
-
-  template <typename Rhs>
-  std::tuple<Table<Ts...>*, DeferredDeleteTag, typename std::decay<Rhs>::type>
-  operator-=(Rhs&& rhs) {
-    return {this, DeferredDeleteTag(), std::forward<Rhs>(rhs)};
   }
 
   void Tick() {


### PR DESCRIPTION
Before, infix operators (i.e. <=, +=, and -=) were methods inside of collections. I thought that it was confusing seeing random infix operators inside collection implementations. Moreover, when someone sees
an infix operator, it's not easy to know where it came from. I moved all the infix operators into a single file, moved them into a namespace, and made them all free functions.