### PR TITLE
Added bootstrapping.

### DIFF
--- a/src/examples/chat/client.cc
+++ b/src/examples/chat/client.cc
@@ -29,33 +29,22 @@ int main(int argc, char* argv[]) {
   const std::string nickname = argv[3];
   zmq::context_t context(1);
 
+  std::vector<std::tuple<server_address_t, client_address_t, nickname_t>>
+      connect_tuple = {{server_address, client_address, nickname}};
+
   auto f =
       fluent::fluent(client_address, &context)
           .stdin()
           .stdout()
           .channel<server_address_t, client_address_t, nickname_t>("connect")
           .channel<address_t, message_t>("mcast")
-          .table<int>("bootstrap_dummy")
-          .RegisterRules([&](auto& in, auto& out, auto& connect, auto& mcast,
-                             auto& dummy) {
+          .RegisterBootstrapRules([&](auto&, auto&, auto& connect, auto&) {
             using namespace fluent::infix;
-
-            auto bootstrap_a =
-                connect <= (dummy.Iterable() | ra::count() |
-                            ra::filter([](const std::tuple<std::size_t>& t) {
-                              return std::get<0>(t) == 0;
-                            }) |
-                            ra::map([&](const std::tuple<std::size_t>&) {
-                              return std::make_tuple(server_address,
-                                                     client_address, nickname);
-                            }));
-
-            auto bootstrap_b =
-                dummy <= (dummy.Iterable() | ra::count() |
-                          ra::map([](const std::tuple<int>& t) {
-                            return std::make_tuple(std::get<0>(t) + 1);
-                          }));
-
+            return std::make_tuple(connect <=
+                                   ra::make_iterable(&connect_tuple));
+          })
+          .RegisterRules([&](auto& in, auto& out, auto&, auto& mcast) {
+            using namespace fluent::infix;
             auto from_in =
                 mcast <=
                 (in.Iterable() |
@@ -65,7 +54,7 @@ int main(int argc, char* argv[]) {
 
             auto to_out = out <= (mcast.Iterable() | ra::project<1>());
 
-            return std::make_tuple(bootstrap_a, bootstrap_b, from_in, to_out);
+            return std::make_tuple(from_in, to_out);
           });
 
   f.Run();


### PR DESCRIPTION
In Bloom, you could register rules to be run exactly once at the beginning of the fluent program. Before this commit, you could do that too with some cleverness, but it was very awkward (see the chat
applicatoin before this commit).

This commit introduces bootstrapping as a first class citizen. Now, programmers can do something like the following to register bootstrap rules and bootstrap rules.

```c++
auto f = fluent(address)
  .table<int, char, float>("t1")
  .table<float, int>("t2")
  .scratch<int, int, float>("s")
  .channel<std::string, float, char>("c")
  .RegisterBootstrapRules([&](auto& t1, auto& t2, auto& s, auto& c) {
    return std::make_tuple(t1 <= ra::make_iterable(&tuples));
  });
  .RegisterRules([](auto& t1, auto& t2, auto& s, auto& c) {
    return std::make_tuple(t2 <= t1.iterable | ra::project<2, 0>());
  });
```

I've also rewritten the chat application to take advantage of bootstrapping.

Fixes #39.