### PR TITLE
Column names

### DIFF
--- a/scripts/reset_database.sql
+++ b/scripts/reset_database.sql
@@ -14,6 +14,7 @@ CREATE TABLE Collections (
     node_id         bigint NOT NULL,
     collection_name text   NOT NULL,
     collection_type text   NOT NULL,
+    column_names    text[] NOT NULL,
     PRIMARY KEY (node_id, collection_name)
 );
 

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -4,18 +4,6 @@
 
 namespace fluent {
 
-std::string Join(const std::vector<std::string>& ss) {
-  std::string s = "";
-  if (ss.size() == 0) {
-    return s;
-  }
-  for (std::size_t i = 0; i < ss.size() - 1; ++i) {
-    s += ss[i] + ", ";
-  }
-  s += ss[ss.size() - 1];
-  return s;
-}
-
 std::string CrunchWhitespace(std::string s) {
   // Replace newlines with spaces.
   std::replace(s.begin(), s.end(), '\n', ' ');

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -1,16 +1,36 @@
 #ifndef COMMON_STRING_UTIL_H_
 #define COMMON_STRING_UTIL_H_
 
+#include <cstddef>
+
+#include <array>
 #include <string>
 #include <vector>
 
 namespace fluent {
+namespace detail {
+
+template <typename Iterator>
+std::string JoinIterators(Iterator begin, Iterator end) {
+  std::string s = "";
+  while (begin != end) {
+    s += *begin;
+    begin++;
+    if (begin != end) {
+      s += ", ";
+    }
+  }
+  return s;
+}
+
+}  // namespace detail
 
 // Join() = ""
 // Join(1) = "1"
 // Join(1, "2") = "1, 2"
 // Join(1, "2", '3') = "1, 2, 3"
 // Join(std::vector<std::string>{"1", "2", "3"}) = "1, 2, 3"
+// Join(std::array<std::string, 3>{"1", "2", "3"}) = "1, 2, 3"
 inline std::string Join() { return ""; }
 
 inline std::string Join(const std::string& x) { return x; }
@@ -30,7 +50,14 @@ std::string Join(const T& x, const Ts&... xs) {
   return std::to_string(x) + ", " + Join(xs...);
 }
 
-std::string Join(const std::vector<std::string>& ss);
+inline std::string Join(const std::vector<std::string>& ss) {
+  return detail::JoinIterators(ss.cbegin(), ss.cend());
+}
+
+template <std::size_t N>
+std::string Join(const std::array<std::string, N>& ss) {
+  return detail::JoinIterators(ss.cbegin(), ss.cend());
+}
 
 // CrunchWhitespace converts newlines to spaces and then destutters spaces.
 //

--- a/src/common/string_util_test.cc
+++ b/src/common/string_util_test.cc
@@ -16,9 +16,15 @@ TEST(StringUtil, Join) {
   EXPECT_EQ(Join("a"s, "bc"s), "a, bc"s);
   EXPECT_EQ(Join("a"s, "bc"s, "def"s), "a, bc, def"s);
 
+  EXPECT_EQ(Join(std::vector<std::string>{}), ""s);
   EXPECT_EQ(Join(std::vector<std::string>{"a"}), "a"s);
   EXPECT_EQ(Join(std::vector<std::string>{"a", "b"}), "a, b"s);
   EXPECT_EQ(Join(std::vector<std::string>{"a", "b", "c"}), "a, b, c"s);
+
+  EXPECT_EQ(Join(std::array<std::string, 0>{}), ""s);
+  EXPECT_EQ(Join(std::array<std::string, 1>{{"a"}}), "a"s);
+  EXPECT_EQ(Join(std::array<std::string, 2>{{"a", "b"}}), "a, b"s);
+  EXPECT_EQ(Join(std::array<std::string, 3>{{"a", "b", "c"}}), "a, b, c"s);
 }
 
 TEST(StringUtil, CrunchWhitespace) {

--- a/src/common/type_list.h
+++ b/src/common/type_list.h
@@ -138,6 +138,19 @@ template <typename... Ts>
 struct TypeListLen<TypeList<Ts...>>
     : public std::integral_constant<std::size_t, sizeof...(Ts)> {};
 
+// All
+template <typename TypeList, template <typename> class F>
+struct TypeListAll;
+
+template <template <typename> class F>
+struct TypeListAll<TypeList<>, F> : public std::true_type {};
+
+template <typename T, typename... Ts, template <typename> class F>
+struct TypeListAll<TypeList<T, Ts...>, F> {
+  static constexpr bool value =
+      F<T>::value && TypeListAll<TypeList<Ts...>, F>::value;
+};
+
 // AllSame
 template <typename TypeList>
 struct TypeListAllSame;
@@ -145,13 +158,12 @@ struct TypeListAllSame;
 template <>
 struct TypeListAllSame<TypeList<>> : public std::true_type {};
 
-template <typename T>
-struct TypeListAllSame<TypeList<T>> : public std::true_type {};
+template <typename T, typename... Ts>
+struct TypeListAllSame<TypeList<T, Ts...>> {
+  template <typename U>
+  using is_t = std::is_same<T, U>;
 
-template <typename T, typename U, typename... Us>
-struct TypeListAllSame<TypeList<T, U, Us...>> {
-  static constexpr bool value =
-      std::is_same<T, U>::value && TypeListAllSame<TypeList<U, Us...>>::value;
+  static constexpr bool value = TypeListAll<TypeList<Ts...>, is_t>::value;
 };
 
 // TypeListTo<Template, TypeList<Ts...>> = Template<Ts...>

--- a/src/common/type_list_test.cc
+++ b/src/common/type_list_test.cc
@@ -88,6 +88,15 @@ TEST(TypeList, TypeListLen) {
   static_assert(TypeListLen<four>::value == 4, "");
 }
 
+TEST(TypeList, TypeListAll) {
+  static_assert(TypeListAll<TypeList<>, std::is_void>::value, "");
+  static_assert(TypeListAll<TypeList<void>, std::is_void>::value, "");
+  static_assert(TypeListAll<TypeList<void, void>, std::is_void>::value, "");
+  static_assert(!TypeListAll<TypeList<int>, std::is_void>::value, "");
+  static_assert(!TypeListAll<TypeList<void, int>, std::is_void>::value, "");
+  static_assert(!TypeListAll<TypeList<int, void>, std::is_void>::value, "");
+}
+
 TEST(TypeList, TypeListAllSame) {
   using a = TypeList<>;
   using b = TypeList<int>;

--- a/src/common/type_traits.h
+++ b/src/common/type_traits.h
@@ -2,6 +2,7 @@
 #define COMMON_TYPE_TRAITS_H_
 
 #include <set>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/src/examples/chat/server.h
+++ b/src/examples/chat/server.h
@@ -13,12 +13,6 @@
 
 namespace ra = fluent::ra;
 
-using address_t = std::string;
-using server_address_t = std::string;
-using client_address_t = std::string;
-using nickname_t = std::string;
-using message_t = std::string;
-
 struct ServerArgs {
   std::string server_address;
 };
@@ -28,28 +22,30 @@ template <template <template <typename> class, template <typename> class>
 int ServerMain(const ServerArgs& args,
                const fluent::lineagedb::ConnectionConfig& connection_config) {
   zmq::context_t context(1);
-  auto f =
-      fluent::fluent<LineageDbClient>("chat_server", args.server_address,
-                                      &context, connection_config)
-          .template channel<server_address_t, client_address_t, nickname_t>(
-              "connect")
-          .template channel<address_t, message_t>("mcast")
-          .template table<client_address_t, nickname_t>("nodelist")
-          .RegisterRules([&](auto& connect, auto& mcast, auto& nodelist) {
-            using namespace fluent::infix;
+  auto f = fluent::fluent<LineageDbClient>("chat_server", args.server_address,
+                                           &context, connection_config)
+               .template channel<std::string, std::string, std::string>(
+                   "connect", {{"server_addr", "client_addr", "nickname"}})
+               .template channel<std::string, std::string>("mcast",
+                                                           {{"addr", "msg"}})
+               .template table<std::string, std::string>(
+                   "nodelist", {{"client_addr", "nickname"}})
+               .RegisterRules([&](auto& connect, auto& mcast, auto& nodelist) {
+                 using namespace fluent::infix;
 
-            auto subscribe =
-                nodelist <= (connect.Iterable() | ra::project<1, 2>());
+                 auto subscribe =
+                     nodelist <= (connect.Iterable() | ra::project<1, 2>());
 
-            // TODO(mwhittaker): Currently, nicknames are not being used. We
-            // should prepend the nickaname of the sender to the message before
-            // broadcasting it.
-            auto multicast = mcast <= (ra::make_cross(mcast.Iterable(),
-                                                      nodelist.Iterable()) |
-                                       ra::project<2, 1>());
+                 // TODO(mwhittaker): Currently, nicknames are not being used.
+                 // We should prepend the nickaname of the sender to the
+                 // message before broadcasting it.
+                 auto multicast =
+                     mcast <=
+                     (ra::make_cross(mcast.Iterable(), nodelist.Iterable()) |
+                      ra::project<2, 1>());
 
-            return std::make_tuple(subscribe, multicast);
-          });
+                 return std::make_tuple(subscribe, multicast);
+               });
 
   f.Run();
   return 0;

--- a/src/fluent/README.md
+++ b/src/fluent/README.md
@@ -10,10 +10,10 @@ zmq::context_t context(1);
 ConnectionConfig conn;
 std::set<std::tuple<int, char, float>> ts = {{42, 'a', 9001.}};
 auto f = fluent<NoopClient>("name", "tcp://0.0.0.0:8000", &context, conn)
-  .table<int, char, float>("t1")
-  .table<float, int>("t2")
-  .scratch<int, int, float>("s")
-  .channel<std::string, float, char>("c")
+  .table<int, char, float>("t1", {{"x", "y", "z"}})
+  .table<float, int>("t2" {{"x", "y"}})
+  .scratch<int, int, float>("s", {{"x", "y"}})
+  .channel<std::string, float, char>("c", {{"addr", "x", "y"}})
   .RegisterBootstrapRules([&](auto& t1, auto& t2, auto& s, auto& c) {
     return std::make_tuple(t1 <= ra::make_iterable("ts", &ts));
   })
@@ -38,18 +38,18 @@ that you can ignore for now. Next, we declare the collections our program will
 use:
 
 ```c++
-  .table<int, char, float>("t1")
-  .table<float, int>("t2")
-  .scratch<int, int, float>("s")
-  .channel<std::string, float, char>("c")
+  .table<int, char, float>("t1", {{"x", "y", "z"}})
+  .table<float, int>("t2" {{"x", "y"}})
+  .scratch<int, int, float>("s", {{"x", "y"}})
+  .channel<std::string, float, char>("c", {{"addr", "x", "y"}})
 ```
 
 This code declares that our fluent program will use
 
-1. a 3-column table named `t1` with types `int`, `char`, and `float`;
-2. a 2-column table named `t2` with types `float` and `int`;
-3. a 3-column scratch named `s` with types `int`, `int`, and `float`; and
-4. a 3-column channel named `c` with types `string`, `float`, and `char`.
+1. a 3-column table `t1(x:int, y:char, z:float)`;
+2. a 2-column table `t2(x:float, y:int)`;
+3. a 3-column scratch `s(x:int, y:int, z:float)`; and
+4. a 3-column channel `c(addr:string, x:float, y:char)`;
 
 Next, we register a single bootstrap rule.
 

--- a/src/fluent/channel.h
+++ b/src/fluent/channel.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 
 #include <algorithm>
+#include <array>
 #include <set>
 #include <type_traits>
 #include <utility>
@@ -12,6 +13,7 @@
 #include "gtest/gtest.h"
 #include "range/v3/all.hpp"
 
+#include "common/macros.h"
 #include "common/type_traits.h"
 #include "fluent/rule_tags.h"
 #include "fluent/serialization.h"
@@ -58,10 +60,22 @@ class Channel {
                 "ZeroMQ address (e.g. tcp://localhost:9999).");
 
  public:
-  Channel(std::size_t id, std::string name, SocketCache* socket_cache)
-      : id_(id), name_(std::move(name)), socket_cache_(socket_cache) {}
+  Channel(std::size_t id, std::string name,
+          std::array<std::string, 1 + sizeof...(Ts)> column_names,
+          SocketCache* socket_cache)
+      : id_(id),
+        name_(std::move(name)),
+        column_names_(std::move(column_names)),
+        socket_cache_(socket_cache) {}
+  Channel(Channel&&) = default;
+  Channel& operator=(Channel&&) = default;
+  DISALLOW_COPY_AND_ASSIGN(Channel);
 
   const std::string& Name() const { return name_; }
+
+  const std::array<std::string, 1 + sizeof...(Ts)>& ColumnNames() const {
+    return column_names_;
+  }
 
   const std::set<std::tuple<T, Ts...>>& Get() const { return ts_; }
 
@@ -116,6 +130,7 @@ class Channel {
  private:
   const std::size_t id_;
   const std::string name_;
+  const std::array<std::string, 1 + sizeof...(Ts)> column_names_;
   std::set<std::tuple<T, Ts...>> ts_;
 
   // Whenever a tuple with address `a` is added to a Channel, the socket

--- a/src/fluent/channel_test.cc
+++ b/src/fluent/channel_test.cc
@@ -21,7 +21,7 @@ using ::testing::UnorderedElementsAreArray;
 TEST(Channel, SimpleMerge) {
   zmq::context_t context(1);
   SocketCache cache(&context);
-  Channel<std::string, int, int> c(42, "c", &cache);
+  Channel<std::string, int, int> c(42, "c", {{"addr", "x", "y"}}, &cache);
 
   const std::string a_address = "inproc://a";
   const std::string b_address = "inproc://b";
@@ -60,7 +60,7 @@ TEST(Channel, TickClearsChannel) {
 
   zmq::context_t context(1);
   SocketCache cache(&context);
-  Channel<std::string, int, int> c(42, "c", &cache);
+  Channel<std::string, int, int> c(42, "c", {{"addr", "x", "y"}}, &cache);
 
   c.ts_.insert(Tuple("foo", 1, 1));
   c.ts_.insert(Tuple("bar", 2, 2));

--- a/src/fluent/fluent_builder_test.cc
+++ b/src/fluent/fluent_builder_test.cc
@@ -20,29 +20,29 @@ namespace fluent {
 TEST(FluentBuilder, SimpleBuildCheck) {
   zmq::context_t context(1);
   lineagedb::ConnectionConfig conf;
-  // clang-format off
-  auto f = fluent<lineagedb::NoopClient>("name", "inproc://yolo", &context, conf)
-    .table<std::string, int>("t")
-    .scratch<std::string, int>("s")
-    .channel<std::string, int>("c")
-    .stdin()
-    .stdout()
-    .periodic("p", std::chrono::milliseconds(100))
-    .RegisterRules([](auto& t, auto& s, auto& c, auto& in, auto& out, auto& p) {
-      using namespace fluent::infix;
-      (void) in.Iterable();
-      (void) p.Iterable();
-      auto rule_a = t <= s.Iterable();
-      auto rule_b = t += s.Iterable();
-      auto rule_c = t -= s.Iterable();
-      auto rule_d = s <= s.Iterable();
-      auto rule_e = c <= s.Iterable();
-      auto rule_f = out <= (s.Iterable() | ra::project<0>());
-      auto rule_g = out += (s.Iterable() | ra::project<0>());
-      return std::make_tuple(rule_a, rule_b, rule_c, rule_d, rule_e,
-                             rule_f, rule_g);
-    });
-  // clang-format on
+  auto f =
+      fluent<lineagedb::NoopClient>("name", "inproc://yolo", &context, conf)
+          .table<std::string, int>("t", {{"x", "y"}})
+          .scratch<std::string, int>("s", {{"x", "y"}})
+          .channel<std::string, int>("c", {{"addr", "x"}})
+          .stdin()
+          .stdout()
+          .periodic("p", std::chrono::milliseconds(100))
+          .RegisterRules(
+              [](auto& t, auto& s, auto& c, auto& in, auto& out, auto& p) {
+                using namespace fluent::infix;
+                (void)in.Iterable();
+                (void)p.Iterable();
+                auto rule_a = t <= s.Iterable();
+                auto rule_b = t += s.Iterable();
+                auto rule_c = t -= s.Iterable();
+                auto rule_d = s <= s.Iterable();
+                auto rule_e = c <= s.Iterable();
+                auto rule_f = out <= (s.Iterable() | ra::project<0>());
+                auto rule_g = out += (s.Iterable() | ra::project<0>());
+                return std::make_tuple(rule_a, rule_b, rule_c, rule_d, rule_e,
+                                       rule_f, rule_g);
+              });
 }
 
 }  // namespace fluent

--- a/src/fluent/fluent_executor.h
+++ b/src/fluent/fluent_executor.h
@@ -265,8 +265,8 @@ class FluentExecutor<
   template <typename Collection, typename... Ts>
   void AddCollection(const std::unique_ptr<Collection>& c, TypeList<Ts...>) {
     lineagedb_client_->template AddCollection<Ts...>(
-        c->Name(),
-        CollectionTypeToString(GetCollectionType<Collection>::value));
+        c->Name(), CollectionTypeToString(GetCollectionType<Collection>::value),
+        c->ColumnNames());
   }
 
   // Tick a collection and insert the deleted tuples into the lineagedb

--- a/src/fluent/fluent_executor_test.cc
+++ b/src/fluent/fluent_executor_test.cc
@@ -41,9 +41,9 @@ TEST(FluentExecutor, SimpleProgram) {
   zmq::context_t context(1);
   lineagedb::ConnectionConfig connection_config;
   auto f = noopfluent("name", "inproc://yolo", &context, connection_config)
-               .table<std::size_t>("t")
-               .scratch<int, int, float>("s")
-               .channel<std::string, float, char>("c")
+               .table<std::size_t>("t", {{"x"}})
+               .scratch<int, int, float>("s", {{"x", "y", "z"}})
+               .channel<std::string, float, char>("c", {{"addr", "x", "y"}})
                .RegisterRules([](auto& t, auto& s, auto& c) {
                  using namespace fluent::infix;
                  return std::make_tuple(t <= (t.Iterable() | ra::count()),
@@ -79,8 +79,8 @@ TEST(FluentExecutor, SimpleBootstrap) {
   lineagedb::ConnectionConfig connection_config;
   auto f =
       noopfluent("name", "inproc://yolo", &context, connection_config)
-          .table<int>("t")
-          .scratch<int>("s")
+          .table<int>("t", {{"x"}})
+          .scratch<int>("s", {{"x"}})
           .RegisterBootstrapRules([&xs](auto& t, auto& s) {
             using namespace fluent::infix;
             return std::make_tuple(t <= ra::make_iterable("xs", &xs),
@@ -104,8 +104,8 @@ TEST(FluentExecutor, MildlyComplexProgram) {
   lineagedb::ConnectionConfig connection_config;
   auto f =
       noopfluent("name", "inproc://yolo", &context, connection_config)
-          .table<std::size_t>("t")
-          .scratch<std::size_t>("s")
+          .table<std::size_t>("t", {{"x"}})
+          .scratch<std::size_t>("s", {{"x"}})
           .stdout()
           .RegisterRules([&](auto& t, auto& s, auto& stdout) {
             using namespace fluent::infix;
@@ -149,8 +149,8 @@ TEST(FluentExecutor, ComplexProgram) {
   zmq::context_t context(1);
   lineagedb::ConnectionConfig connection_config;
   auto f = noopfluent("name", "inproc://yolo", &context, connection_config)
-               .table<std::size_t>("t")
-               .scratch<std::size_t>("s")
+               .table<std::size_t>("t", {{"x"}})
+               .scratch<std::size_t>("s", {{"x"}})
                .RegisterRules([plus_one_times_two, is_even](auto& t, auto& s) {
                  using namespace fluent::infix;
                  auto a = t += (s.Iterable() | ra::count());
@@ -187,7 +187,7 @@ TEST(FluentExecutor, SimpleCommunication) {
   lineagedb::ConnectionConfig connection_config;
   auto ping =
       noopfluent("name", "inproc://ping", &context, connection_config)
-          .channel<std::string, int>("c")
+          .channel<std::string, int>("c", {{"addr", "x"}})
           .RegisterRules([&reroute](auto& c) {
             using namespace fluent::infix;
             return std::make_tuple(
@@ -195,7 +195,7 @@ TEST(FluentExecutor, SimpleCommunication) {
           });
   auto pong =
       noopfluent("name", "inproc://pong", &context, connection_config)
-          .channel<std::string, int>("c")
+          .channel<std::string, int>("c", {{"addr", "x"}})
           .RegisterRules([&reroute](auto& c) {
             using namespace fluent::infix;
             return std::make_tuple(
@@ -226,9 +226,9 @@ TEST(FluentExecutor, SimpleProgramWithLineage) {
   lineagedb::ConnectionConfig connection_config;
   auto f = fluent<ldb::MockClient, Hash, ldb::MockToSql>(
                "name", "inproc://yolo", &context, connection_config)
-               .table<std::size_t>("t")
-               .scratch<std::size_t>("s")
-               .channel<std::string, float, char>("c")
+               .table<std::size_t>("t", {{"x"}})
+               .scratch<std::size_t>("s", {{"x"}})
+               .channel<std::string, float, char>("c", {{"addr", "x", "y"}})
                .RegisterRules([](auto& t, auto& s, auto& c) {
                  using namespace fluent::infix;
                  return std::make_tuple(t <= (t.Iterable() | ra::count()),

--- a/src/fluent/fluent_executor_test.cc
+++ b/src/fluent/fluent_executor_test.cc
@@ -252,11 +252,12 @@ TEST(FluentExecutor, SimpleProgramWithLineage) {
   EXPECT_TRUE(client.GetInit());
   ASSERT_EQ(client.GetAddRule().size(), static_cast<std::size_t>(3));
   EXPECT_EQ(client.GetAddCollection()[0],
-            AddCollectionTuple("t", "Table", {"unsigned long"}));
+            AddCollectionTuple("t", "Table", {"x"}, {"unsigned long"}));
   EXPECT_EQ(client.GetAddCollection()[1],
-            AddCollectionTuple("s", "Scratch", {"unsigned long"}));
+            AddCollectionTuple("s", "Scratch", {"x"}, {"unsigned long"}));
   EXPECT_EQ(client.GetAddCollection()[2],
-            AddCollectionTuple("c", "Channel", {"string", "float", "char"}));
+            AddCollectionTuple("c", "Channel", {"addr", "x", "y"},
+                               {"string", "float", "char"}));
   ASSERT_EQ(client.GetAddCollection().size(), static_cast<std::size_t>(3));
   EXPECT_EQ(client.GetAddRule()[0], AddRuleTuple(0, false, "t <= Count(t)"));
   EXPECT_EQ(client.GetAddRule()[1], AddRuleTuple(1, false, "t <= Count(s)"));

--- a/src/fluent/infix.h
+++ b/src/fluent/infix.h
@@ -29,8 +29,8 @@ namespace infix {
 // following snippet of code.
 //
 //   using namespace fluent::infix;
-//   Table<int> t;
-//   Scratch<float> s;
+//   Table<int> t("t", {{"x"}});
+//   Scratch<float> s("s", {{"y"}});
 //   auto rule = t <= s.Iterable() | ra::count();
 //
 // Here, `rule` is the tuple `(&t, MergeTag(), s.Iterable() | ra::count())`.

--- a/src/fluent/periodic.h
+++ b/src/fluent/periodic.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <set>
 #include <string>
@@ -48,6 +49,11 @@ class Periodic {
   DISALLOW_COPY_AND_ASSIGN(Periodic);
 
   const std::string& Name() const { return name_; }
+
+  const std::array<std::string, 2>& ColumnNames() const {
+    static std::array<std::string, 2> column_names{{"id", "time"}};
+    return column_names;
+  }
 
   const period& Period() const { return period_; }
 

--- a/src/fluent/rule_test.cc
+++ b/src/fluent/rule_test.cc
@@ -13,7 +13,7 @@
 namespace fluent {
 
 TEST(Rule, ToDebugString) {
-  Table<int> t("t");
+  Table<int> t("t", {{"x"}});
   std::set<std::tuple<int>> xs;
   const Rule<Table<int>*, MergeTag, ra::Iterable<std::set<std::tuple<int>>>>
       rule{&t, MergeTag(), ra::make_iterable("xs", &xs)};

--- a/src/fluent/scratch.h
+++ b/src/fluent/scratch.h
@@ -2,10 +2,12 @@
 #define FLUENT_SCRATCH_H_
 
 #include <algorithm>
+#include <array>
 #include <set>
 #include <string>
 #include <tuple>
 
+#include "common/macros.h"
 #include "common/type_traits.h"
 #include "ra/iterable.h"
 
@@ -14,9 +16,17 @@ namespace fluent {
 template <typename... Ts>
 class Scratch {
  public:
-  explicit Scratch(std::string name) : name_(std::move(name)) {}
+  Scratch(std::string name, std::array<std::string, sizeof...(Ts)> column_names)
+      : name_(std::move(name)), column_names_(std::move(column_names)) {}
+  Scratch(Scratch&&) = default;
+  Scratch& operator=(Scratch&&) = default;
+  DISALLOW_COPY_AND_ASSIGN(Scratch);
 
   const std::string& Name() const { return name_; }
+
+  const std::array<std::string, sizeof...(Ts)>& ColumnNames() const {
+    return column_names_;
+  }
 
   const std::set<std::tuple<Ts...>>& Get() const { return ts_; }
 
@@ -36,6 +46,7 @@ class Scratch {
 
  private:
   const std::string name_;
+  const std::array<std::string, sizeof...(Ts)> column_names_;
   std::set<std::tuple<Ts...>> ts_;
 };
 

--- a/src/fluent/scratch_test.cc
+++ b/src/fluent/scratch_test.cc
@@ -13,7 +13,7 @@ namespace fluent {
 using ::testing::UnorderedElementsAreArray;
 
 TEST(Scratch, SimpleMerge) {
-  Scratch<int, int> s("s");
+  Scratch<int, int> s("s", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty;
   std::set<std::tuple<int, int>> s1 = {{1, 1}, {2, 2}};
   std::set<std::tuple<int, int>> s2 = {{2, 2}, {3, 3}};
@@ -27,7 +27,7 @@ TEST(Scratch, SimpleMerge) {
 }
 
 TEST(Scratch, TickClearsScratches) {
-  Scratch<int, int> s("s");
+  Scratch<int, int> s("s", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty = {};
   std::set<std::tuple<int, int>> ts = {{1, 1}, {2, 2}};
 

--- a/src/fluent/stdin.h
+++ b/src/fluent/stdin.h
@@ -2,6 +2,7 @@
 #define FLUENT_STDIN_H_
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <set>
 #include <string>
@@ -23,6 +24,11 @@ class Stdin {
   const std::string& Name() const {
     static const std::string name = "stdin";
     return name;
+  }
+
+  const std::array<std::string, 1>& ColumnNames() const {
+    static std::array<std::string, 1> column_names{{"stdin"}};
+    return column_names;
   }
 
   ra::Iterable<std::set<std::tuple<std::string>>> Iterable() const {

--- a/src/fluent/stdout.h
+++ b/src/fluent/stdout.h
@@ -2,6 +2,7 @@
 #define FLUENT_STDOUT_H_
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <iterator>
 #include <set>
@@ -24,6 +25,11 @@ class Stdout {
   const std::string& Name() const {
     static const std::string name = "stdout";
     return name;
+  }
+
+  const std::array<std::string, 1>& ColumnNames() const {
+    static std::array<std::string, 1> column_names{{"stdout"}};
+    return column_names;
   }
 
   void Merge(const std::set<std::tuple<std::string>>& ts) {

--- a/src/fluent/table.h
+++ b/src/fluent/table.h
@@ -2,7 +2,7 @@
 #define FLUENT_TABLE_H_
 
 #include <algorithm>
-#include <algorithm>
+#include <array>
 #include <iterator>
 #include <set>
 #include <type_traits>
@@ -10,6 +10,7 @@
 
 #include "range/v3/all.hpp"
 
+#include "common/macros.h"
 #include "common/type_traits.h"
 #include "ra/iterable.h"
 
@@ -18,9 +19,18 @@ namespace fluent {
 template <typename... Ts>
 class Table {
  public:
-  explicit Table(std::string name) : name_(std::move(name)) {}
+  template <typename... Strings>
+  Table(std::string name, std::array<std::string, sizeof...(Ts)> column_names)
+      : name_(std::move(name)), column_names_(std::move(column_names)) {}
+  Table(Table&&) = default;
+  Table& operator=(Table&&) = default;
+  DISALLOW_COPY_AND_ASSIGN(Table);
 
   const std::string& Name() const { return name_; }
+
+  const std::array<std::string, sizeof...(Ts)>& ColumnNames() const {
+    return column_names_;
+  }
 
   const std::set<std::tuple<Ts...>>& Get() const { return ts_; }
 
@@ -55,6 +65,7 @@ class Table {
 
  private:
   const std::string name_;
+  const std::array<std::string, sizeof...(Ts)> column_names_;
   std::set<std::tuple<Ts...>> ts_;
   std::set<std::tuple<Ts...>> deferred_merge_;
   std::set<std::tuple<Ts...>> deferred_delete_;

--- a/src/fluent/table_test.cc
+++ b/src/fluent/table_test.cc
@@ -35,7 +35,7 @@ const C& thd(const std::tuple<A, B, C>& t) {
 }  // namespace
 
 TEST(Table, SimpleMerge) {
-  Table<int, int> t("t");
+  Table<int, int> t("t", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty;
   std::set<std::tuple<int, int>> s1 = {{1, 1}, {2, 2}};
   std::set<std::tuple<int, int>> s2 = {{2, 2}, {3, 3}};
@@ -49,7 +49,7 @@ TEST(Table, SimpleMerge) {
 }
 
 TEST(Table, SimpleDeferredMerge) {
-  Table<int, int> t("t");
+  Table<int, int> t("t", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty = {};
   std::set<std::tuple<int, int>> s1 = {{1, 1}, {2, 2}};
   std::set<std::tuple<int, int>> s2 = {{2, 2}, {3, 3}};
@@ -65,7 +65,7 @@ TEST(Table, SimpleDeferredMerge) {
 }
 
 TEST(Table, SimpleDeferredDelete) {
-  Table<int, int> t("t");
+  Table<int, int> t("t", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty = {};
   std::set<std::tuple<int, int>> s1 = {{1, 1}, {2, 2}};
   std::set<std::tuple<int, int>> s2 = {{2, 2}, {3, 3}};
@@ -86,7 +86,7 @@ TEST(Table, SimpleDeferredDelete) {
 }
 
 TEST(Table, DeferredMergeAndDelete) {
-  Table<int, int> t("t");
+  Table<int, int> t("t", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty = {};
   std::set<std::tuple<int, int>> s1 = {{1, 1}, {2, 2}};
   std::set<std::tuple<int, int>> s2 = {{2, 2}, {3, 3}};
@@ -102,7 +102,7 @@ TEST(Table, DeferredMergeAndDelete) {
 }
 
 TEST(Table, TickDoesntClearTable) {
-  Table<int, int> t("t");
+  Table<int, int> t("t", {{"x", "y"}});
   std::set<std::tuple<int, int>> empty;
   std::set<std::tuple<int, int>> s = {{1, 1}, {2, 2}};
 

--- a/src/frontend/main.py
+++ b/src/frontend/main.py
@@ -15,13 +15,15 @@ def get_collection_names(cur, node_name):
 def get_collection(cur, node_name, collection_name, time):
     collection = {"name": collection_name, "type": "", "tuples": []}
 
-    # Type
+    # Type, Column Names
     cur.execute("""
-        SELECT collection_type
+        SELECT collection_type, column_names
         FROM Collections
         WHERE collection_name = %s;
     """, (collection_name, ))
-    collection["type"] = cur.fetchone()[0]
+    t = cur.fetchone()
+    collection["type"] = t[0]
+    collection["column_names"] = t[1]
 
     # Tuples
     cur.execute("""
@@ -88,7 +90,9 @@ def node():
             FROM {}_{};
         """.format(node_name, collection_name))
         times.append(cur.fetchone()[0])
-    max_time = max(times)
+    # If no rules have been executed at all, then max(times) is None and we
+    # default to a time of 0.
+    max_time = max(times) or 0
 
     # Collections.
     collections = [get_collection(cur, node_name, collection_name, max_time)

--- a/src/frontend/static/index.js
+++ b/src/frontend/static/index.js
@@ -18,39 +18,19 @@ fluent.ajax_get = function(url, on_success) {
   return xhr;
 }
 
-// `create_html_table(rows: string list list)` returns an html table created
-// from `rows`. For example, if rows is [["a", "b", "c"], ["d", "e", "f"]], the
-// returned table will look like this:
-//
-//   <table>
-//     <tr> <td>a</td> <td>b</td> <td>c</td> </tr>
-//     <tr> <td>e</td> <td>e</td> <td>f</td> </tr>
-//   </table>
-fluent.create_html_table = function(rows) {
-    var table = document.createElement("table");
-    for (var i = 0; i < rows.length; ++i) {
-        var row = document.createElement("tr");
-        for (var j = 0; j < rows[i].length; ++j) {
-            var element = document.createElement("td");
-            element.innerHTML = rows[i][j];
-            row.appendChild(element);
-        }
-        table.appendChild(row);
-    }
-    return table;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Types
 ////////////////////////////////////////////////////////////////////////////////
 // type Collection = {
 //   name: string,
 //   type: string,
+//   column_names: string list,
 //   tuples: string list list,
 // }
-fluent.Collection = function(name, type, tuples) {
+fluent.Collection = function(name, type, column_names, tuples) {
     this.name = name;
     this.type = type;
+    this.column_names = column_names;
     this.tuples = tuples;
 }
 
@@ -514,6 +494,15 @@ fluent.render_collection = function(state, state_ui, collection, index) {
     collection_type.innerHTML = ": " + collection.type;
 
     var tuples = document.createElement("table");
+
+    var row = document.createElement("tr");
+    for (var i = 0; i < collection.column_names.length; ++i) {
+        var element = document.createElement("th");
+        element.innerHTML = collection.column_names[i];
+        row.appendChild(element);
+    }
+    tuples.appendChild(row);
+
     for (var i = 0; i < collection.tuples.length; ++i) {
         var tuple = collection.tuples[i];
         var row = document.createElement("tr");

--- a/src/lineagedb/README.md
+++ b/src/lineagedb/README.md
@@ -76,9 +76,9 @@ exactly is stored, it's best to look at an example:
 zmq::context_t context(1);
 postgres::ConnectionConfig config = GetConnectionConfig();
 auto f = fluent<PqxxClient>("my_program", "inproc://addr", &context, config)
-  .table<int, char>("my_table")
-  .scratch<int>("my_scratch")
-  .channel<std::string, float>("my_channel")
+  .table<int, char>("my_table", {{"x", "y"}})
+  .scratch<int>("my_scratch", {{"x"}})
+  .channel<std::string, float>("my_channel", {{"addr", "x"})
   .RegisterRules([](auto& t, auto& s, auto& c) {
     using namespace fluent::infix;
     return std::make_tuple(s <= c.Iterable(), t <= s.Iterable());
@@ -87,9 +87,9 @@ auto f = fluent<PqxxClient>("my_program", "inproc://addr", &context, config)
 
 This fluent program has three collections---
 
-- a table `my_table(int, char)`,
-- a scratch `my_scratch(int)`, and
-- a channel `my_channel(std::string, float)`.
+- a table `my_table(x:int, y:char)`,
+- a scratch `my_scratch(x:int)`, and
+- a channel `my_channel(addr:std::string, x:float)`.
 
 ---and two rules:
 
@@ -101,8 +101,8 @@ Information about this program, its collections, and its rules are found in the
 
 - The `Nodes(id, name, address)` relation holds the name, id (the hash of the
   name), and address for every fluent program.
-- The `Collections(node_id, collection_name, collection_type)` relation holds
-  the name and type of every collection of every fluent program.
+- The `Collections(node_id, collection_name, collection_type, column_names)`
+  relation holds the name and type of every collection of every fluent program.
 - The `Rules(node_id, rule_number, is_bootstrap, rule)` relation holds every
   rule of every fluent program.
 
@@ -115,13 +115,13 @@ Information about this program, its collections, and its rules are found in the
 +----+------------+-----------+
 
 > SELECT * FROM Collections;
-+---------+-----------------+-----------------+
-| node_id | collection_name | collection_type |
-|---------+-----------------+-----------------+
-| 42      | my_table        | Table           |
-| 42      | my_sratch       | Scratch         |
-| 42      | my_channel      | Channel         |
-+---------+-----------------+-----------------+
++---------+-----------------+-----------------+---------------+
+| node_id | collection_name | collection_type | column_names  |
+|---------+-----------------+-----------------+---------------+
+| 42      | my_table        | Table           | ['x', 'y']    |
+| 42      | my_sratch       | Scratch         | ['x']         |
+| 42      | my_channel      | Channel         | ['addr', 'x'] |
++---------+-----------------+-----------------+---------------+
 
 > SELECT * FROM Rules;
 +---------+-------------+--------------+--------+

--- a/src/lineagedb/mock_client_test.cc
+++ b/src/lineagedb/mock_client_test.cc
@@ -27,17 +27,18 @@ TEST(MockClient, Init) {
 
 TEST(MockClient, AddCollection) {
   MockClient<Hash, MockToSql> client("", 42, "", ConnectionConfig());
-  client.AddCollection<>("fee", "Fee");
-  client.AddCollection<int>("fi", "Fi");
-  client.AddCollection<int, bool>("fo", "Fo");
-  client.AddCollection<int, bool, char>("fum", "Fum");
+  client.AddCollection<>("fee", "Fee", {{}});
+  client.AddCollection<int>("fi", "Fi", {{"x"}});
+  client.AddCollection<int, bool>("fo", "Fo", {{"x", "y"}});
+  client.AddCollection<int, bool, char>("fum", "Fum", {{"x", "y", "z"}});
 
   using Tuple = MockClient<Hash, MockToSql>::AddCollectionTuple;
-  EXPECT_EQ(client.GetAddCollection()[0], Tuple("fee", "Fee", {}));
-  EXPECT_EQ(client.GetAddCollection()[1], Tuple("fi", "Fi", {"int"}));
-  EXPECT_EQ(client.GetAddCollection()[2], Tuple("fo", "Fo", {"int", "bool"}));
+  EXPECT_EQ(client.GetAddCollection()[0], Tuple("fee", "Fee", {}, {}));
+  EXPECT_EQ(client.GetAddCollection()[1], Tuple("fi", "Fi", {"x"}, {"int"}));
+  EXPECT_EQ(client.GetAddCollection()[2],
+            Tuple("fo", "Fo", {"x", "y"}, {"int", "bool"}));
   EXPECT_EQ(client.GetAddCollection()[3],
-            Tuple("fum", "Fum", {"int", "bool", "char"}));
+            Tuple("fum", "Fum", {"x", "y", "z"}, {"int", "bool", "char"}));
 }
 
 TEST(MockClient, AddRule) {

--- a/src/lineagedb/mock_pqxx_client_test.cc
+++ b/src/lineagedb/mock_pqxx_client_test.cc
@@ -51,13 +51,14 @@ TEST(MockPqxxClient, AddCollection) {
   ConnectionConfig c;
   MockPqxxClient<Hash, ToSql> client("name", 9001, "127.0.0.1", c);
   client.Init();
-  client.AddCollection<int, char, bool>("t", "Table");
+  client.AddCollection<int, char, bool>("t", "Table", {{"x", "c", "b"}});
 
   std::vector<std::pair<std::string, std::string>> queries = client.Queries();
   ASSERT_EQ(queries.size(), static_cast<std::size_t>(4));
   ExpectStringsEqualIgnoreWhiteSpace(queries[2].second, R"(
-    INSERT INTO Collections (node_id, collection_name, collection_type)
-    VALUES (9001, 't', 'Table');
+    INSERT INTO Collections (node_id, collection_name, collection_type,
+                             column_names)
+    VALUES (9001, 't', 'Table', ['x', 'c', 'b']);
   )");
   ExpectStringsEqualIgnoreWhiteSpace(queries[3].second, R"(
     CREATE TABLE name_t (

--- a/src/lineagedb/mock_pqxx_client_test.cc
+++ b/src/lineagedb/mock_pqxx_client_test.cc
@@ -65,9 +65,9 @@ TEST(MockPqxxClient, AddCollection) {
       hash          bigint  NOT NULL,
       time_inserted integer NOT NULL,
       time_deleted  integer,
-      col_0 integer NOT NULL,
-      col_1 char(1) NOT NULL,
-      col_2 boolean NOT NULL,
+      x integer NOT NULL,
+      c char(1) NOT NULL,
+      b boolean NOT NULL,
       PRIMARY KEY (hash, time_inserted)
     );
   )");

--- a/src/lineagedb/mock_pqxx_client_test.cc
+++ b/src/lineagedb/mock_pqxx_client_test.cc
@@ -58,7 +58,7 @@ TEST(MockPqxxClient, AddCollection) {
   ExpectStringsEqualIgnoreWhiteSpace(queries[2].second, R"(
     INSERT INTO Collections (node_id, collection_name, collection_type,
                              column_names)
-    VALUES (9001, 't', 'Table', ['x', 'c', 'b']);
+    VALUES (9001, 't', 'Table', ARRAY['x', 'c', 'b']);
   )");
   ExpectStringsEqualIgnoreWhiteSpace(queries[3].second, R"(
     CREATE TABLE name_t (

--- a/src/lineagedb/mock_to_sql.h
+++ b/src/lineagedb/mock_to_sql.h
@@ -8,6 +8,8 @@
 
 #include "fmt/format.h"
 
+#include "common/string_util.h"
+
 namespace fluent {
 namespace lineagedb {
 
@@ -82,6 +84,21 @@ template <>
 struct MockToSql<double> {
   std::string Type() { return "double"; }
   std::string Value(double x) { return std::to_string(x); }
+};
+
+template <typename T, std::size_t N>
+struct MockToSql<std::array<T, N>> {
+  std::string Type() {
+    return fmt::format("array<{}, {}>", MockToSql<T>().Type(), N);
+  }
+
+  std::string Value(const std::array<T, N>& xs) {
+    std::vector<std::string> values;
+    for (const T& x : xs) {
+      values.push_back(MockToSql<T>().Value(x));
+    }
+    return fmt::format("[{}]", Join(values));
+  }
 };
 
 }  // namespace lineagedb

--- a/src/lineagedb/mock_to_sql_test.cc
+++ b/src/lineagedb/mock_to_sql_test.cc
@@ -21,6 +21,7 @@ TEST(MockToSql, ToSqlType) {
   EXPECT_EQ(MockToSql<long long>().Type(), "long long");
   EXPECT_EQ(MockToSql<float>().Type(), "float");
   EXPECT_EQ(MockToSql<double>().Type(), "double");
+  EXPECT_EQ((MockToSql<std::array<int, 2>>().Type()), "array<int, 2>");
 }
 
 TEST(MockToSql, ToSqlValue) {
@@ -34,6 +35,7 @@ TEST(MockToSql, ToSqlValue) {
   EXPECT_EQ(MockToSql<std::int64_t>().Value(5), "5");
   EXPECT_EQ(MockToSql<float>().Value(6.0), "6.000000");
   EXPECT_EQ(MockToSql<double>().Value(7.0), "7.000000");
+  EXPECT_EQ((MockToSql<std::array<int, 2>>().Value({{1, 2}})), "[1, 2]");
 }
 
 }  // namespace lineagedb

--- a/src/lineagedb/noop_client.h
+++ b/src/lineagedb/noop_client.h
@@ -1,6 +1,11 @@
 #ifndef LINEAGEDB_NOOP_CLIENT_H_
 #define LINEAGEDB_NOOP_CLIENT_H_
 
+#include <cstddef>
+
+#include <array>
+#include <string>
+
 #include "lineagedb/connection_config.h"
 
 namespace fluent {
@@ -18,7 +23,8 @@ class NoopClient {
   void Init() {}
 
   template <typename... Ts>
-  void AddCollection(const std::string&, const std::string&) {}
+  void AddCollection(const std::string&, const std::string&,
+                     const std::array<std::string, sizeof...(Ts)>&) {}
 
   void AddRule(std::size_t, bool, const std::string&) {}
 

--- a/src/lineagedb/pqxx_client.h
+++ b/src/lineagedb/pqxx_client.h
@@ -131,8 +131,9 @@ class InjectablePqxxClient {
   }
 
   template <typename... Ts>
-  void AddCollection(const std::string& collection_name,
-                     const std::string& collection_type) {
+  void AddCollection(
+      const std::string& collection_name, const std::string& collection_type,
+      const std::array<std::string, sizeof...(Ts)>& column_names) {
     static_assert(sizeof...(Ts) > 0, "Collections should have >= 1 column.");
     CHECK(initialized_) << "Call Init first.";
 
@@ -142,13 +143,16 @@ class InjectablePqxxClient {
     CHECK_NE(collection_name, std::string("lineage"))
         << "Lineage is a reserved collection name.";
 
-    ExecuteQuery("AddCollection",
-                 fmt::format(R"(
-      INSERT INTO Collections (node_id, collection_name, collection_type)
+    ExecuteQuery(
+        "AddCollection",
+        fmt::format(
+            R"(
+      INSERT INTO Collections (node_id, collection_name, collection_type,
+                               column_names)
       VALUES ({});
     )",
-                             Join(SqlValues(std::make_tuple(
-                                 id_, collection_name, collection_type)))));
+            Join(SqlValues(std::make_tuple(id_, collection_name,
+                                           collection_type, column_names)))));
 
     std::vector<std::string> types = SqlTypes<Ts...>();
     std::vector<std::string> columns;

--- a/src/lineagedb/pqxx_client.h
+++ b/src/lineagedb/pqxx_client.h
@@ -157,7 +157,8 @@ class InjectablePqxxClient {
     std::vector<std::string> types = SqlTypes<Ts...>();
     std::vector<std::string> columns;
     for (std::size_t i = 0; i < types.size(); ++i) {
-      columns.push_back(fmt::format("col_{} {} NOT NULL", i, types[i]));
+      columns.push_back(
+          fmt::format("{} {} NOT NULL", column_names[i], types[i]));
     }
     ExecuteQuery("AddCollectionTable",
                  fmt::format(R"(

--- a/src/lineagedb/to_sql.h
+++ b/src/lineagedb/to_sql.h
@@ -118,12 +118,13 @@ struct ToSql<double> {
 template <typename T, std::size_t N>
 struct ToSql<std::array<T, N>> {
   std::string Type() { return fmt::format("{}[]", ToSql<T>().Type()); }
+
   std::string Value(const std::array<T, N>& xs) {
     std::vector<std::string> values;
     for (const T& x : xs) {
       values.push_back(ToSql<T>().Value(x));
     }
-    return fmt::format("[{}]", Join(values));
+    return fmt::format("ARRAY[{}]", Join(values));
   }
 };
 

--- a/src/lineagedb/to_sql.h
+++ b/src/lineagedb/to_sql.h
@@ -3,11 +3,14 @@
 
 #include <cstdint>
 
+#include <array>
 #include <chrono>
 #include <string>
 #include <type_traits>
 
 #include "fmt/format.h"
+
+#include "common/string_util.h"
 
 namespace fluent {
 namespace lineagedb {
@@ -110,6 +113,18 @@ template <>
 struct ToSql<double> {
   std::string Type() { return "double precision"; }
   std::string Value(double x) { return std::to_string(x); }
+};
+
+template <typename T, std::size_t N>
+struct ToSql<std::array<T, N>> {
+  std::string Type() { return fmt::format("{}[]", ToSql<T>().Type()); }
+  std::string Value(const std::array<T, N>& xs) {
+    std::vector<std::string> values;
+    for (const T& x : xs) {
+      values.push_back(ToSql<T>().Value(x));
+    }
+    return fmt::format("[{}]", Join(values));
+  }
 };
 
 template <typename Clock>

--- a/src/lineagedb/to_sql_test.cc
+++ b/src/lineagedb/to_sql_test.cc
@@ -23,6 +23,9 @@ TEST(ToSql, ToSqlType) {
   EXPECT_EQ(ToSql<float>().Type(), "real");
   EXPECT_EQ(ToSql<double>().Type(), "double precision");
   EXPECT_EQ(ToSql<double>().Type(), "double precision");
+  EXPECT_EQ(ToSql<double>().Type(), "double precision");
+  EXPECT_EQ((ToSql<std::array<int, 0>>().Type()), "integer[]");
+  EXPECT_EQ((ToSql<std::array<bool, 1>>().Type()), "boolean[]");
   // TODO(mwhittaker): Test ToSql<std::chrono::time_point<Clock>>.
 }
 
@@ -37,6 +40,9 @@ TEST(ToSql, ToSqlValue) {
   EXPECT_EQ(ToSql<std::int64_t>().Value(5), "5");
   EXPECT_EQ(ToSql<float>().Value(6.0), "6.000000");
   EXPECT_EQ(ToSql<double>().Value(7.0), "7.000000");
+  EXPECT_EQ((ToSql<std::array<int, 0>>().Value({{}})), "[]");
+  EXPECT_EQ((ToSql<std::array<bool, 2>>().Value({{true, false}})),
+            "[true, false]");
   // TODO(mwhittaker): Test ToSql<std::chrono::time_point<Clock>>.
 }
 

--- a/src/lineagedb/to_sql_test.cc
+++ b/src/lineagedb/to_sql_test.cc
@@ -40,9 +40,9 @@ TEST(ToSql, ToSqlValue) {
   EXPECT_EQ(ToSql<std::int64_t>().Value(5), "5");
   EXPECT_EQ(ToSql<float>().Value(6.0), "6.000000");
   EXPECT_EQ(ToSql<double>().Value(7.0), "7.000000");
-  EXPECT_EQ((ToSql<std::array<int, 0>>().Value({{}})), "[]");
+  EXPECT_EQ((ToSql<std::array<int, 0>>().Value({{}})), "ARRAY[]");
   EXPECT_EQ((ToSql<std::array<bool, 2>>().Value({{true, false}})),
-            "[true, false]");
+            "ARRAY[true, false]");
   // TODO(mwhittaker): Test ToSql<std::chrono::time_point<Clock>>.
 }
 


### PR DESCRIPTION
![screenshot from 2017-04-13 22 57 45](https://cloud.githubusercontent.com/assets/3654277/25034637/be680da8-209c-11e7-8363-67fefdf88b16.png)

Added column names to Fluent. Now, creating a fluent program looks like this. 
```c++
auto f = fluent<NoopClient>("name", "tcp://0.0.0.0:8000", &context, conn)
  .table<int, char, float>("t1", {{"x", "y", "z"}})
  .table<float, int>("t2" {{"x", "y"}})
  .scratch<int, int, float>("s", {{"x", "y"}})
  .channel<std::string, float, char>("c", {{"addr", "x", "y"}})
  .RegisterBootstrapRules([&](auto& t1, auto& t2, auto& s, auto& c) {
    return std::make_tuple(t1 <= ra::make_iterable("ts", &ts));
  })
  .RegisterRules([](auto& t1, auto& t2, auto& s, auto& c) {
    return std::make_tuple(t2 <= t1.iterable | ra::project<2, 0>());
  });
```

Column names are put in the lineage database and are used by the frontend. If you provide an incorrect number of channel names, the code won't compile. That's nice :)