### PR TITLE
Recording insertion times in lineage.

### DIFF
--- a/src/fluent/fluent_executor.h
+++ b/src/fluent/fluent_executor.h
@@ -753,10 +753,10 @@ class FluentExecutor<
             rule->collection->Name(), time_, Clock::now(), tuple));
       }
 
-      for (const LocalTupleId& id : ids) {
+      for (const LocalTupleId& dep_id : ids) {
         RETURN_IF_ERROR(lineagedb_client_->AddDerivedLineage(
-            id.collection_name, id.hash, rule_number, is_insert, physical_time,
-            rule->collection->Name(), hash(tuple), time_));
+            dep_id, rule_number, is_insert, physical_time,
+            LocalTupleId{rule->collection->Name(), hash(tuple), time_}));
       }
 
       physical_time = Clock::now();

--- a/src/fluent/fluent_executor_test.cc
+++ b/src/fluent/fluent_executor_test.cc
@@ -515,11 +515,13 @@ TEST(FluentExecutor, SimpleProgramWithLineage) {
             static_cast<std::size_t>(0));
   ASSERT_EQ(client.GetAddDerivedLineage().size(), static_cast<std::size_t>(2));
   EXPECT_EQ(client.GetAddDerivedLineage()[0],
-            AddDerivedLineageTuple("t", hash({0}), 0, true,
-                                   time_point(seconds(1)), "s", hash({1}), 3));
+            AddDerivedLineageTuple(LocalTupleId{"t", hash({0}), 1}, 0, true,
+                                   time_point(seconds(1)),
+                                   LocalTupleId{"s", hash({1}), 3}));
   EXPECT_EQ(client.GetAddDerivedLineage()[1],
-            AddDerivedLineageTuple("s", hash({1}), 1, true,
-                                   time_point(seconds(1)), "t", hash({1}), 4));
+            AddDerivedLineageTuple(LocalTupleId{"s", hash({1}), 3}, 1, true,
+                                   time_point(seconds(1)),
+                                   LocalTupleId{"t", hash({1}), 4}));
 
   MockClock::Advance(seconds(1));
   ASSERT_EQ(Status::OK, f.Tick());
@@ -550,17 +552,21 @@ TEST(FluentExecutor, SimpleProgramWithLineage) {
             static_cast<std::size_t>(0));
   ASSERT_EQ(client.GetAddDerivedLineage().size(), static_cast<std::size_t>(6));
   EXPECT_EQ(client.GetAddDerivedLineage()[2],
-            AddDerivedLineageTuple("t", hash({0}), 0, true,
-                                   time_point(seconds(2)), "s", hash({1}), 6));
+            AddDerivedLineageTuple(LocalTupleId{"t", hash({0}), 1}, 0, true,
+                                   time_point(seconds(2)),
+                                   LocalTupleId{"s", hash({1}), 6}));
   EXPECT_EQ(client.GetAddDerivedLineage()[3],
-            AddDerivedLineageTuple("t", hash({1}), 0, true,
-                                   time_point(seconds(2)), "s", hash({2}), 6));
+            AddDerivedLineageTuple(LocalTupleId{"t", hash({1}), 4}, 0, true,
+                                   time_point(seconds(2)),
+                                   LocalTupleId{"s", hash({2}), 6}));
   EXPECT_EQ(client.GetAddDerivedLineage()[4],
-            AddDerivedLineageTuple("s", hash({1}), 1, true,
-                                   time_point(seconds(2)), "t", hash({1}), 7));
+            AddDerivedLineageTuple(LocalTupleId{"s", hash({1}), 6}, 1, true,
+                                   time_point(seconds(2)),
+                                   LocalTupleId{"t", hash({1}), 7}));
   EXPECT_EQ(client.GetAddDerivedLineage()[5],
-            AddDerivedLineageTuple("s", hash({2}), 1, true,
-                                   time_point(seconds(2)), "t", hash({2}), 7));
+            AddDerivedLineageTuple(LocalTupleId{"s", hash({2}), 6}, 1, true,
+                                   time_point(seconds(2)),
+                                   LocalTupleId{"t", hash({2}), 7}));
 }
 
 TEST(FluentExecutor, BlackBoxLineage) {

--- a/src/lineagedb/README.md
+++ b/src/lineagedb/README.md
@@ -180,7 +180,7 @@ Additionally, for each program `p`, we generate a `p_lineage` table:
 | dep_node_id         | bigint                   | not null  |
 | dep_collection_name | text                     | not null  |
 | dep_tuple_hash      | bigint                   | not null  |
-| dep_time            | integer                  |           |
+| dep_time            | integer                  | not null  |
 | rule number         | integer                  |           |
 | inserted            | boolean                  | not null  |
 | physical_time       | timestamp with time zone | not null  |

--- a/src/lineagedb/mock_client.h
+++ b/src/lineagedb/mock_client.h
@@ -13,6 +13,7 @@
 #include "common/status_or.h"
 #include "common/tuple_util.h"
 #include "common/type_list.h"
+#include "fluent/local_tuple_id.h"
 #include "lineagedb/connection_config.h"
 
 namespace fluent {
@@ -111,14 +112,12 @@ class MockClient {
     return Status::OK;
   }
 
-  WARN_UNUSED Status AddDerivedLineage(
-      const std::string& dep_collection_name, std::size_t dep_tuple_hash,
-      int rule_number, bool inserted,
-      const std::chrono::time_point<Clock>& physical_time,
-      const std::string& collection_name, std::size_t tuple_hash, int time) {
-    add_derived_lineage_.push_back(std::make_tuple(
-        dep_collection_name, dep_tuple_hash, rule_number, inserted,
-        physical_time, collection_name, tuple_hash, time));
+  WARN_UNUSED Status
+  AddDerivedLineage(const LocalTupleId& dep_id, int rule_number, bool inserted,
+                    const std::chrono::time_point<Clock>& physical_time,
+                    const LocalTupleId& id) {
+    add_derived_lineage_.push_back(
+        std::make_tuple(dep_id, rule_number, inserted, physical_time, id));
     return Status::OK;
   }
 
@@ -150,8 +149,8 @@ class MockClient {
   // dep_collection_name, dep_tuple_hash, rule_number, inserted, physical_time,
   // collection_name, tuple_hash, time
   using AddDerivedLineageTuple =
-      std::tuple<std::string, std::size_t, int, bool,
-                 std::chrono::time_point<Clock>, std::string, std::size_t, int>;
+      std::tuple<LocalTupleId, int, bool, std::chrono::time_point<Clock>,
+                 LocalTupleId>;
   // query
   using RegisterBlackBoxLineageTuple =
       std::tuple<std::string, std::vector<std::string>>;

--- a/src/lineagedb/mock_client_test.cc
+++ b/src/lineagedb/mock_client_test.cc
@@ -145,23 +145,34 @@ TEST(MockClient, AddDerivedLineage) {
   ASSERT_EQ(Status::OK, client_or.status());
   Client client = client_or.ConsumeValueOrDie();
   ASSERT_EQ(Status::OK,
-            (client.AddDerivedLineage("0", 1, 2, true, time_point(seconds(1)),
-                                      "3", 4, 5)));
+            (client.AddDerivedLineage(LocalTupleId{"0", 1, 2},          //
+                                      3, true, time_point(seconds(1)),  //
+                                      LocalTupleId{"4", 5, 6})));
   ASSERT_EQ(Status::OK,
-            (client.AddDerivedLineage("10", 11, 12, true,
-                                      time_point(seconds(2)), "13", 14, 15)));
+            (client.AddDerivedLineage(LocalTupleId{"10", 11, 12},  //
+                                      13, true,
+                                      time_point(seconds(2)),  //
+                                      LocalTupleId{"14", 15, 16})));
   ASSERT_EQ(Status::OK,
-            (client.AddDerivedLineage("20", 21, 22, true,
-                                      time_point(seconds(3)), "23", 24, 25)));
+            (client.AddDerivedLineage(LocalTupleId{"20", 21, 22},  //
+                                      23, true,
+                                      time_point(seconds(3)),  //
+                                      LocalTupleId{"24", 25, 26})));
 
   using Tuple = MockClient<Hash, MockToSql, MockClock>::AddDerivedLineageTuple;
   ASSERT_EQ(client.GetAddDerivedLineage().size(), static_cast<std::size_t>(3));
   EXPECT_EQ(client.GetAddDerivedLineage()[0],
-            Tuple("0", 1, 2, true, time_point(seconds(1)), "3", 4, 5));
+            Tuple(LocalTupleId{"0", 1, 2},          //
+                  3, true, time_point(seconds(1)),  //
+                  LocalTupleId{"4", 5, 6}));
   EXPECT_EQ(client.GetAddDerivedLineage()[1],
-            Tuple("10", 11, 12, true, time_point(seconds(2)), "13", 14, 15));
+            Tuple(LocalTupleId{"10", 11, 12},        //
+                  13, true, time_point(seconds(2)),  //
+                  LocalTupleId{"14", 15, 16}));
   EXPECT_EQ(client.GetAddDerivedLineage()[2],
-            Tuple("20", 21, 22, true, time_point(seconds(3)), "23", 24, 25));
+            Tuple(LocalTupleId{"20", 21, 22},        //
+                  23, true, time_point(seconds(3)),  //
+                  LocalTupleId{"24", 25, 26}));
 }
 
 TEST(MockClient, RegisterBlackBoxLineage) {

--- a/src/lineagedb/noop_client.h
+++ b/src/lineagedb/noop_client.h
@@ -10,6 +10,7 @@
 #include "common/macros.h"
 #include "common/status.h"
 #include "common/status_or.h"
+#include "fluent/local_tuple_id.h"
 #include "lineagedb/connection_config.h"
 
 namespace fluent {
@@ -62,10 +63,9 @@ class NoopClient {
     return Status::OK;
   }
 
-  WARN_UNUSED Status AddDerivedLineage(const std::string&, std::size_t, int,
-                                       bool,
+  WARN_UNUSED Status AddDerivedLineage(const LocalTupleId&, int, bool,
                                        const std::chrono::time_point<Clock>&,
-                                       const std::string&, std::size_t, int) {
+                                       const LocalTupleId&) {
     return Status::OK;
   }
 


### PR DESCRIPTION
Before we kept track of insertion times, we did not insert them into lineage. Now that we do, we can!